### PR TITLE
Improve stability options

### DIFF
--- a/.github/workflows/fork.yml
+++ b/.github/workflows/fork.yml
@@ -1,0 +1,14 @@
+---
+name: fork
+
+"on":
+  schedule:
+    - cron: "*/30 * * * *"
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: TG908/fork-sync@v1.1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,11 @@
 FROM alpine:3.11
 
+WORKDIR /
+
 COPY LICENSE README.md /
 
-# RUN apk --no-cache add lftp
-RUN apk --no-cache add ncftp
-
+RUN apk --no-cache add \
+    lftp=4.8.4-r2
 COPY entrypoint.sh /entrypoint.sh
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,9 +1,9 @@
 #!/bin/sh -l
 
 lftp ${INPUT_HOST} -u ${INPUT_USER},${INPUT_PASSWORD} -e "
-  set net:timeout 10;
-  set net:max-retries 1;
-  set net:reconnect-interval-multiplier 1;
+  set net:timeout 60;
+  set net:max-retries 20;
+  set net:reconnect-interval-multiplier 2;
   set net:reconnect-interval-base 5;
   set ftp:ssl-force $INPUT_FORCESSL; 
   set sftp:auto-confirm yes;

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,17 +1,13 @@
 #!/bin/sh -l
 
-# lftp $INPUT_HOST -u $INPUT_USER,$INPUT_PASSWORD -e "set ftp:ssl-force $INPUT_FORCESSL; set ssl:verify-certificate false; mirror --reverse --continue --dereference --verbose=3 -P -x ^\.git/$ $INPUT_LOCALDIR $INPUT_REMOTEDIR; quit"
-
-lftp -e "
-  set net:timeout 5;
-  set net:max-retries 3;
+lftp ${INPUT_HOST} -u ${INPUT_USER},${INPUT_PASSWORD} -e "
+  set net:timeout 60;
+  set net:max-retries 20;
   set net:reconnect-interval-multiplier 1;
   set net:reconnect-interval-base 5;
   set ftp:ssl-force $INPUT_FORCESSL; 
   set sftp:auto-confirm yes;
   set ssl:verify-certificate $INPUT_FORCESSL; 
-  open $INPUT_HOST
-  user $INPUT_USER $INPUT_PASSWORD
-  mirror -v -P 5 -R $INPUT_LOCALDIR $INPUT_REMOTEDIR;
+  mirror -v -P 5 -R -x ^\.git/$ $INPUT_LOCALDIR $INPUT_REMOTEDIR;
   quit
 "

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,6 +8,6 @@ lftp ${INPUT_HOST} -u ${INPUT_USER},${INPUT_PASSWORD} -e "
   set ftp:ssl-force $INPUT_FORCESSL; 
   set sftp:auto-confirm yes;
   set ssl:verify-certificate $INPUT_FORCESSL; 
-  mirror -v -P 5 -R -x ^\.git/$ $INPUT_LOCALDIR $INPUT_REMOTEDIR;
+  mirror -v -P 5 -R -L -x ^\.git/$ $INPUT_LOCALDIR $INPUT_REMOTEDIR;
   quit
 "

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,13 +1,13 @@
 #!/bin/sh -l
 
 lftp ${INPUT_HOST} -u ${INPUT_USER},${INPUT_PASSWORD} -e "
-  set net:timeout 60;
-  set net:max-retries 20;
+  set net:timeout 10;
+  set net:max-retries 1;
   set net:reconnect-interval-multiplier 1;
   set net:reconnect-interval-base 5;
   set ftp:ssl-force $INPUT_FORCESSL; 
   set sftp:auto-confirm yes;
   set ssl:verify-certificate $INPUT_FORCESSL; 
-  mirror -v -P 5 -R -L -x ^\.git/$ $INPUT_LOCALDIR $INPUT_REMOTEDIR;
+  mirror -v -P 5 -R -n -L -x ^\.git/$ $INPUT_LOCALDIR $INPUT_REMOTEDIR;
   quit
 "


### PR DESCRIPTION
This leads to more stable connections (more retries, longer timeout), only loading newer files (-n), loading symbolic links as files (-L) as well as specifically excluding the git directory (-x ^\.git/$)